### PR TITLE
Add Linuxbrew support and bootstrap checks

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -9,6 +9,7 @@ packages:
       - dejan/lazygit
       - gsauthof/dracut-sshd
       - kylegospo/grub-btrfs
+      - scottames/ghostty
 
   casks:
     - name: whatcable
@@ -16,30 +17,7 @@ packages:
       tap: darrylmorley/whatcable
       cask: whatcable
 
-  uv_tools:
-    - name: cmake-language-server
-      group: development
-      package: cmake-language-server
-      command: cmake-language-server
-      with: [pygls==1.3.1]
-      skip: [darwin]
-    - name: mdformat
-      group: development
-      package: mdformat==1.0.0
-      with: [mdformat-gfm==1.0.0]
-      skip: [darwin]
-    - name: stylua
-      group: development
-      package: git+https://github.com/johnnymorganz/stylua@v2.5.2
-      skip: [darwin]
-    - name: taplo
-      group: development
-      package: taplo==0.9.3
-      skip: [darwin]
-    - name: yamlfmt
-      group: development
-      package: google-yamlfmt==0.21.0
-      skip: [darwin]
+  uv_tools: []
 
   catalog:
     # Core: Always-installed CLI foundation.
@@ -57,12 +35,16 @@ packages:
       managers: [apt]
     - name: ca-certificates
       managers: [apt, dnf, pacman]
+    - name: cargo
+      managers: [dnf]
     - name: curl
       managers: [apt, dnf, pacman]
     - name: direnv
     - name: fontconfig
       managers: [apt, dnf, pacman]
     - name: fzf
+    - name: ghostty
+      managers: [dnf]
     - name: git
     - name: git-gui
       managers: [brew, apt, dnf]
@@ -71,18 +53,19 @@ packages:
     - name: lsd
     - name: neovim
     - name: proton-pass-cli
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: ripgrep
     - name: rsync
       managers: [apt, dnf, pacman]
+    - name: rust
+      managers: [brew, dnf]
     - name: shellcheck
     - name: shfmt
     - name: tldr
+      managers: [brew, linuxbrew]
       names:
-        apt: tealdeer
-        dnf: tealdeer
-        pacman: tealdeer
         brew: tlrc
+        linuxbrew: tlrc
     - name: tmux
     - name: tree
     - name: tree-sitter-cli
@@ -109,10 +92,10 @@ packages:
       group: development
     - name: cmake-language-server
       group: development
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: code-minimap
       group: development
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: gdb
       group: development
       managers: [apt, dnf, pacman, brew]
@@ -143,7 +126,7 @@ packages:
       managers: [apt, dnf, pacman]
     - name: mdformat
       group: development
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: meson
       group: development
     - name: ninja
@@ -167,16 +150,16 @@ packages:
       managers: [apt, dnf, pacman]
     - name: stylua
       group: development
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: taplo
       group: development
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: uv
       group: development
       managers: [brew, dnf, pacman]
     - name: yamlfmt
       group: development
-      managers: [brew]
+      managers: [brew, linuxbrew]
     - name: zig
       group: development
       managers: [brew, dnf, pacman]

--- a/home/.chezmoiscripts/run_onchange_after_05-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_05-packages.sh.tmpl
@@ -1,13 +1,14 @@
 #!/bin/sh
 set -eu
 
-{{ $profiles := .profiles | default (list) }}
-{{ $owned := has "owned" $profiles }}
-{{ define "packageLines" }}
+{{- $profiles := .profiles | default (list) -}}
+
+{{- define "packageLines" -}}
 {{- $manager := index . 0 -}}
-{{- $profiles := index . 1 -}}
-{{- $catalog := index . 2 -}}
+{{- $catalog := index . 1 | default (list) -}}
+{{- $profiles := index . 2 | default (list) -}}
 {{- $defaultManagers := list "brew" "apt" "dnf" "pacman" -}}
+
 {{- range $pkg := $catalog -}}
 {{- $name := get $pkg "name" -}}
 {{- $group := get $pkg "group" | default "core" -}}
@@ -15,12 +16,13 @@ set -eu
 {{- $names := get $pkg "names" | default (dict) -}}
 {{- $enabledGroup := or (eq $group "core") (has $group $profiles) -}}
 {{- $enabledManager := has $manager $managers -}}
+
 {{- if and $name $enabledGroup $enabledManager -}}
 {{- $packageName := get $names $manager | default $name -}}
-{{- printf "%s\n" $packageName -}}
+{{ printf "%s\n" $packageName }}
 {{- end -}}
 {{- end -}}
-{{ end }}
+{{- end }}
 
 {{ define "caskLines" }}
 {{- $profiles := index . 0 -}}
@@ -41,10 +43,10 @@ set -eu
 {{- end -}}
 {{ end }}
 
-PROFILE_OWNED="{{ if $owned }}true{{ else }}false{{ end }}"
+PROFILE_OWNED="{{ if has "owned" $profiles }}true{{ else }}false{{ end }}"
 
 BREW_PACKAGES="$(cat <<'EOF'
-{{ template "packageLines" (list "brew" $profiles .packages.catalog) }}
+{{ template "packageLines" (list "brew" .packages.catalog $profiles) }}
 EOF
 )"
 
@@ -53,8 +55,13 @@ BREW_CASKS="$(cat <<'EOF'
 EOF
 )"
 
+LINUXBREW_PACKAGES="$(cat <<'EOF'
+{{ template "packageLines" (list "linuxbrew" .packages.catalog $profiles) }}
+EOF
+)"
+
 APT_PACKAGES="$(cat <<'EOF'
-{{ template "packageLines" (list "apt" $profiles .packages.catalog) }}
+{{ template "packageLines" (list "apt" .packages.catalog $profiles) }}
 EOF
 )"
 
@@ -66,12 +73,12 @@ EOF
 )"
 
 DNF_PACKAGES="$(cat <<'EOF'
-{{ template "packageLines" (list "dnf" $profiles .packages.catalog) }}
+{{ template "packageLines" (list "dnf" .packages.catalog $profiles) }}
 EOF
 )"
 
 PACMAN_PACKAGES="$(cat <<'EOF'
-{{ template "packageLines" (list "pacman" $profiles .packages.catalog) }}
+{{ template "packageLines" (list "pacman" .packages.catalog $profiles) }}
 EOF
 )"
 
@@ -173,6 +180,49 @@ install_brew() {
   install_brew_casks
 }
 
+find_brew() {
+  if command -v brew >/dev/null 2>&1; then
+    command -v brew
+    return 0
+  fi
+
+  for candidate in \
+    /home/linuxbrew/.linuxbrew/bin/brew \
+    "$HOME/.linuxbrew/bin/brew" \
+    /opt/homebrew/bin/brew \
+    /usr/local/bin/brew
+  do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+install_linuxbrew() {
+  if [ -z "$LINUXBREW_PACKAGES" ]; then
+    return 0
+  fi
+
+  brew_command="$(find_brew || true)"
+
+  if [ -z "$brew_command" ]; then
+    printf '%s\n' \
+      'Homebrew was not found; skipping Linuxbrew packages.' >&2
+    return 0
+  fi
+
+  printf 'Installing Linuxbrew packages:\n%s\n' "$LINUXBREW_PACKAGES"
+
+  printf '%s\n' "$LINUXBREW_PACKAGES" |
+    while IFS= read -r package; do
+      [ -n "$package" ] || continue
+      run "$brew_command" install "$package"
+    done
+}
+
 install_apt_ppas() {
   ppas="$(normalize_packages "$APT_PPAS")"
 
@@ -264,6 +314,8 @@ linux)
   else
     printf 'No supported package manager found; skipping packages\n' >&2
   fi
+
+  install_linuxbrew
   ;;
 
 *)

--- a/home/private_dot_zshrc
+++ b/home/private_dot_zshrc
@@ -17,20 +17,40 @@ fi
 
 typeset -U path cdpath fpath manpath
 
-if darwin; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
+brew_bin=""
+
+for candidate in \
+  /opt/homebrew/bin/brew \
+  /usr/local/bin/brew \
+  /home/linuxbrew/.linuxbrew/bin/brew \
+  "$HOME/.linuxbrew/bin/brew"
+do
+  if [[ -x "$candidate" ]]; then
+    brew_bin="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$brew_bin" ]]; then
+  eval "$("$brew_bin" shellenv)"
+
   brew_prefix="$(brew --prefix)"
-  fpath=(
-    "$brew_prefix/share/zsh/functions"
+
+  for completion_dir in \
+    "$brew_prefix/share/zsh/functions" \
     "$brew_prefix/share/zsh/site-functions"
-    "${fpath[@]}"
-  )
+  do
+    if [[ -d "$completion_dir" ]]; then
+      fpath=("$completion_dir" $fpath)
+    fi
+  done
 fi
 
 fpath=(
-  ~/.zsh/completions
+  "$HOME/.zsh/completions"
   $fpath
 )
+unset brew_bin brew_prefix candidate completion_dir
 
 plugins=(
   aliases

--- a/setup.sh
+++ b/setup.sh
@@ -58,6 +58,51 @@ log "DOTFILES_CI=${DOTFILES_CI:-}"
 log "DOTFILES_LOCATION=${DOTFILES_LOCATION:-}"
 log "repo_dir=${repo_dir:-}"
 
+add_homebrew_to_path() {
+  if command -v brew >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for prefix in \
+    /home/linuxbrew/.linuxbrew \
+    "$HOME/.linuxbrew"; do
+    if [ -x "$prefix/bin/brew" ]; then
+      PATH="$prefix/bin:$prefix/sbin:$PATH"
+      export PATH
+      return 0
+    fi
+  done
+}
+
+require_commands() {
+  missing=""
+
+  for command_name in "$@"; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+      missing="${missing}
+  - ${command_name}"
+    fi
+  done
+
+  if [ -z "$missing" ]; then
+    return 0
+  fi
+
+  printf 'Missing bootstrap prerequisites:%s\n' "$missing" >&2
+  printf '%s\n' \
+    'Install these commands before running setup.sh.' \
+    'Fedora example:' \
+    '  sudo dnf install age jq' \
+    '  brew install proton-pass-cli' >&2
+  exit 127
+}
+
+add_homebrew_to_path
+
+if [ "${DOTFILES_CI:-}" != "true" ]; then
+  require_commands age-keygen jq pass-cli
+fi
+
 if [ -n "$repo_dir" ] && [ -f "$repo_dir/.chezmoiroot" ]; then
   log "Using local chezmoi source: $repo_dir"
 


### PR DESCRIPTION
- install selected packages through Linuxbrew on Linux
- add Homebrew environment and completion paths to zsh
- validate age, jq, and Proton Pass prerequisites before apply
- add Fedora Ghostty COPR and Rust toolchain packages
- move shared development tools from uv to Homebrew