### PR TITLE
fix: support Linuxbrew on unmanaged systems

### DIFF
--- a/home/.chezmoiscripts/run_onchange_after_05-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_05-packages.sh.tmpl
@@ -7,7 +7,7 @@ set -eu
 {{- $manager := index . 0 -}}
 {{- $catalog := index . 1 | default (list) -}}
 {{- $profiles := index . 2 | default (list) -}}
-{{- $defaultManagers := list "brew" "apt" "dnf" "pacman" -}}
+{{- $defaultManagers := list "brew" "linuxbrew" "apt" "dnf" "pacman" -}}
 
 {{- range $pkg := $catalog -}}
 {{- $name := get $pkg "name" -}}
@@ -16,6 +16,26 @@ set -eu
 {{- $names := get $pkg "names" | default (dict) -}}
 {{- $enabledGroup := or (eq $group "core") (has $group $profiles) -}}
 {{- $enabledManager := has $manager $managers -}}
+
+{{- if and $name $enabledGroup $enabledManager -}}
+{{- $packageName := get $names $manager | default $name -}}
+{{ printf "%s\n" $packageName }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "explicitPackageLines" -}}
+{{- $manager := index . 0 -}}
+{{- $catalog := index . 1 | default (list) -}}
+{{- $profiles := index . 2 | default (list) -}}
+
+{{- range $pkg := $catalog -}}
+{{- $name := get $pkg "name" -}}
+{{- $group := get $pkg "group" | default "core" -}}
+{{- $managers := get $pkg "managers" | default (list) -}}
+{{- $names := get $pkg "names" | default (dict) -}}
+{{- $enabledGroup := or (eq $group "core") (has $group $profiles) -}}
+{{- $enabledManager := and (hasKey $pkg "managers") (has $manager $managers) -}}
 
 {{- if and $name $enabledGroup $enabledManager -}}
 {{- $packageName := get $names $manager | default $name -}}
@@ -57,6 +77,11 @@ EOF
 
 LINUXBREW_PACKAGES="$(cat <<'EOF'
 {{ template "packageLines" (list "linuxbrew" .packages.catalog $profiles) }}
+EOF
+)"
+
+LINUXBREW_SUPPLEMENTAL_PACKAGES="$(cat <<'EOF'
+{{ template "explicitPackageLines" (list "linuxbrew" .packages.catalog $profiles) }}
 EOF
 )"
 
@@ -214,7 +239,17 @@ find_brew() {
 }
 
 install_linuxbrew() {
-  if [ -z "$LINUXBREW_PACKAGES" ]; then
+  package_block="$LINUXBREW_PACKAGES"
+
+  # Owned Linux machines use the native package manager for normal packages.
+  # Only explicitly Linuxbrew-selected supplemental tools are installed there.
+  if [ "$PROFILE_OWNED" = "true" ] || [ "${DOTFILES_CI:-}" = "true" ]; then
+    package_block="$LINUXBREW_SUPPLEMENTAL_PACKAGES"
+  fi
+
+  packages="$(normalize_packages "$package_block")"
+
+  if [ -z "$packages" ]; then
     return 0
   fi
 
@@ -226,9 +261,9 @@ install_linuxbrew() {
     return 0
   fi
 
-  printf 'Installing Linuxbrew packages:\n%s\n' "$LINUXBREW_PACKAGES"
+  print_packages "Linuxbrew" "$packages"
 
-  printf '%s\n' "$LINUXBREW_PACKAGES" |
+  printf '%s\n' "$packages" |
     while IFS= read -r package; do
       [ -n "$package" ] || continue
       run "$brew_command" install "$package"

--- a/home/dot_zsh/aliases.zsh.tmpl
+++ b/home/dot_zsh/aliases.zsh.tmpl
@@ -1,10 +1,13 @@
-{{- if eq .osid "debian" }}
-alias bat='batcat --theme=Coldark-Dark'
-{{- else }}
-alias bat='bat --theme=Coldark-Dark'
-{{- end }}
-alias less='bat'
-alias more='bat'
+if (( $+commands[batcat] )); then
+  alias bat='batcat --theme=Coldark-Dark'
+elif (( $+commands[bat] )); then
+  alias bat='bat --theme=Coldark-Dark'
+fi
+
+if (( $+aliases[bat] )); then
+  alias less='bat'
+  alias more='bat'
+fi
 
 if (($+commands[duf])); then
   alias df='duf'
@@ -14,20 +17,32 @@ alias egrep='egrep --color=auto'
 alias fgrep='fgrep --color=auto'
 alias grep='grep --color=auto'
 
-alias ls='lsd'
-alias l='ls -1'
-alias la='ls -A'
-alias ll='ls -lah --git'
+if (( $+commands[lsd] )); then
+  alias ls='lsd'
+  alias l='ls -1'
+  alias la='ls -A'
+  alias ll='ls -lah --git'
+else
+  alias l='ls -1'
+  alias la='ls -A'
+  alias ll='ls -lah'
+fi
 
 alias cz='chezmoi'
 alias hookoff='git config --global core.hooksPath /dev/null'
 alias hookon='git config --global --unset core.hooksPath'
-alias tlf='tldr --list | fzf --preview "tldr {1} --color=always" --preview-window=right,70% | xargs tldr'
-alias tmux='tmux -2'
 
-alias dpigs='dpigs -H'
-alias nonascii='ag "[^\x00-\x7F]"'
+if (( $+commands[tldr] && $+commands[fzf] )); then
+  alias tlf='tldr --list | fzf --preview "tldr {1} --color=always" --preview-window=right,70% | xargs tldr'
+fi
+
+(( $+commands[tmux] )) && alias tmux='tmux -2'
+(( $+commands[dpigs] )) && alias dpigs='dpigs -H'
+(( $+commands[ag] )) && alias nonascii='ag "[^\x00-\x7F]"'
+
 alias rot13='tr a-zA-Z n-za-mN-ZA-M'
 
-alias vi='nvim'
-alias vim='nvim'
+if (( $+commands[nvim] )); then
+  alias vi='nvim'
+  alias vim='nvim'
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -eu
 
 GITHUB_REPO="tkk2112/dotfiles"
 PULL_REPO_URL="https://github.com/${GITHUB_REPO}.git"
@@ -74,6 +73,29 @@ add_homebrew_to_path() {
   done
 }
 
+install_bootstrap_prerequisites() {
+  packages=""
+
+  command -v age-keygen >/dev/null 2>&1 || packages="$packages age"
+  command -v jq >/dev/null 2>&1 || packages="$packages jq"
+  command -v pass-cli >/dev/null 2>&1 || packages="$packages proton-pass-cli"
+
+  [ -n "$packages" ] || return 0
+  command -v brew >/dev/null 2>&1 || return 0
+
+  printf 'Installing bootstrap prerequisites with Homebrew:%s\n' "$packages"
+
+  # Linuxbrew can operate without bubblewrap, but must explicitly disable its
+  # sandbox until bubblewrap is available on PATH.
+  if [ "$(uname -s)" = "Linux" ] && ! command -v bwrap >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    run env HOMEBREW_NO_SANDBOX_LINUX=1 brew install $packages
+  else
+    # shellcheck disable=SC2086
+    run brew install $packages
+  fi
+}
+
 require_commands() {
   missing=""
 
@@ -100,7 +122,17 @@ require_commands() {
 add_homebrew_to_path
 
 if [ "${DOTFILES_CI:-}" != "true" ]; then
+  install_bootstrap_prerequisites
   require_commands age-keygen jq pass-cli
+fi
+
+# Chezmoi renders executable scripts in its temporary directory. Some managed
+# systems mount /tmp with noexec, so keep temporary files on the home dataset.
+if [ -z "${TMPDIR:-}" ]; then
+  TMPDIR="${XDG_CACHE_HOME:-$HOME/.cache}/tmp"
+  mkdir -p "$TMPDIR"
+  chmod 700 "$TMPDIR"
+  export TMPDIR
 fi
 
 if [ -n "$repo_dir" ] && [ -f "$repo_dir/.chezmoiroot" ]; then


### PR DESCRIPTION
## Summary

- use Linuxbrew as the fallback package manager on non-owned Linux systems
- keep owned Linux installs limited to explicitly selected Linuxbrew supplements
- install bootstrap prerequisites through Homebrew when it is available
- move chezmoi temporary scripts off potentially `noexec` `/tmp` mounts
- guard aliases so missing optional tools do not replace working system commands

## TrueNAS case

This allows a TrueNAS user with an executable Linuxbrew dataset, but no permission to install system packages, to install the normal core CLI package set through Homebrew.