### PR TITLE
fix: allow degraded installs without optional tools

### DIFF
--- a/home/.chezmoiscripts/run_once_before_05-chezmoi-age-key.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_before_05-chezmoi-age-key.sh.tmpl
@@ -27,20 +27,29 @@ trap cleanup 0 1 2 15
 mkdir -p "$key_dir"
 chmod 700 "$key_dir"
 
-command -v pass-cli >/dev/null 2>&1 || {
-  printf '%s\n' 'pass-cli is required to provision the chezmoi age identity' >&2
-  exit 127
-}
-
-command -v age-keygen >/dev/null 2>&1 || {
-  printf '%s\n' 'age-keygen is required to validate the chezmoi age identity' >&2
-  exit 127
-}
-
-# Preserve an already-migrated real identity file.
+# Preserve an existing real identity even when validation tooling is unavailable.
 if [ -f "$key_file" ] && [ ! -L "$key_file" ]; then
   chmod 600 "$key_file"
-  age-keygen -y "$key_file" >/dev/null
+
+  if command -v age-keygen >/dev/null 2>&1; then
+    age-keygen -y "$key_file" >/dev/null
+  else
+    printf '%s\n' \
+      'age-keygen unavailable; keeping the existing chezmoi age identity'
+  fi
+
+  exit 0
+fi
+
+if ! command -v pass-cli >/dev/null 2>&1; then
+  printf '%s\n' \
+    'Skipping chezmoi age identity provisioning; pass-cli is unavailable'
+  exit 0
+fi
+
+if ! command -v age-keygen >/dev/null 2>&1; then
+  printf '%s\n' \
+    'Skipping chezmoi age identity provisioning; age-keygen is unavailable'
   exit 0
 fi
 

--- a/home/.chezmoiscripts/run_onchange_before_20-proton-pass-ssh-keys.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_20-proton-pass-ssh-keys.sh.tmpl
@@ -2,6 +2,12 @@
 #!/bin/sh
 set -eu
 
+if ! command -v pass-cli >/dev/null 2>&1; then
+  printf '%s\n' \
+    'Skipping Proton Pass SSH key provisioning; pass-cli is unavailable'
+  exit 0
+fi
+
 # Bump this value in ssh.yaml after rotating or replacing a Proton Pass key.
 # chezmoi SSH key revision: {{ .ssh.revision }}
 
@@ -215,4 +221,3 @@ printf 'Provisioned %s %s for %s\n' \
 
 trap - 0 1 2 15
 rm -rf -- "$tmpdir"
-tmpdir=

--- a/setup.sh
+++ b/setup.sh
@@ -121,8 +121,8 @@ should_exclude_encrypted() {
   fi
 
   # The run_once_before age provisioner can create the identity during apply.
-  if command -v age-keygen >/dev/null 2>&1 && \
-    command -v pass-cli >/dev/null 2>&1; then
+  if command -v age-keygen >/dev/null 2>&1 \
+    && command -v pass-cli >/dev/null 2>&1; then
     return 1
   fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -83,47 +83,77 @@ install_bootstrap_prerequisites() {
   [ -n "$packages" ] || return 0
   command -v brew >/dev/null 2>&1 || return 0
 
-  printf 'Installing bootstrap prerequisites with Homebrew:%s\n' "$packages"
+  printf 'Installing optional bootstrap tools with Homebrew:%s\n' "$packages"
 
-  # Linuxbrew can operate without bubblewrap, but must explicitly disable its
-  # sandbox until bubblewrap is available on PATH.
   if [ "$(uname -s)" = "Linux" ] && ! command -v bwrap >/dev/null 2>&1; then
     # shellcheck disable=SC2086
-    run env HOMEBREW_NO_SANDBOX_LINUX=1 brew install $packages
+    run env HOMEBREW_NO_SANDBOX_LINUX=1 brew install $packages || return 0
   else
     # shellcheck disable=SC2086
-    run brew install $packages
+    run brew install $packages || return 0
   fi
 }
 
-require_commands() {
+print_limited_install_notice() {
   missing=""
 
-  for command_name in "$@"; do
+  for command_name in age-keygen jq pass-cli; do
     if ! command -v "$command_name" >/dev/null 2>&1; then
-      missing="${missing}
-  - ${command_name}"
+      missing="${missing} ${command_name}"
     fi
   done
 
-  if [ -z "$missing" ]; then
+  if [ -n "$missing" ]; then
+    printf 'Continuing with a limited install; unavailable optional tools:%s\n' \
+      "$missing" >&2
+  fi
+}
+
+should_exclude_encrypted() {
+  if [ "${DOTFILES_CI:-}" = "true" ]; then
     return 0
   fi
 
-  printf 'Missing bootstrap prerequisites:%s\n' "$missing" >&2
-  printf '%s\n' \
-    'Install these commands before running setup.sh.' \
-    'Fedora example:' \
-    '  sudo dnf install age jq' \
-    '  brew install proton-pass-cli' >&2
-  exit 127
+  key_file="$HOME/.config/chezmoi/key.txt"
+
+  if command -v age >/dev/null 2>&1 && [ -s "$key_file" ]; then
+    return 1
+  fi
+
+  # The run_once_before age provisioner can create the identity during apply.
+  if command -v age-keygen >/dev/null 2>&1 && \
+    command -v pass-cli >/dev/null 2>&1; then
+    return 1
+  fi
+
+  return 0
+}
+
+apply_dotfiles() {
+  source_dir=$1
+  shift
+
+  if should_exclude_encrypted; then
+    printf '%s\n' \
+      'Age identity unavailable; applying everything except encrypted files.' >&2
+
+    if [ -n "$source_dir" ]; then
+      run chezmoi --source "$source_dir" apply --exclude encrypted "$@"
+    else
+      run chezmoi apply --exclude encrypted "$@"
+    fi
+  elif [ -n "$source_dir" ]; then
+    run chezmoi --source "$source_dir" apply "$@"
+  else
+    run chezmoi apply "$@"
+  fi
 }
 
 add_homebrew_to_path
 
 if [ "${DOTFILES_CI:-}" != "true" ]; then
   install_bootstrap_prerequisites
-  require_commands age-keygen jq pass-cli
+  print_limited_install_notice
 fi
 
 # Chezmoi renders executable scripts in its temporary directory. Some managed
@@ -140,19 +170,19 @@ if [ -n "$repo_dir" ] && [ -f "$repo_dir/.chezmoiroot" ]; then
 
   if [ "${DOTFILES_CI:-}" = "true" ]; then
     run chezmoi init --source "$repo_dir" --promptDefaults
-    run chezmoi --source "$repo_dir" apply --exclude encrypted "$@"
   else
     run chezmoi init --source "$repo_dir"
-    run chezmoi --source "$repo_dir" apply "$@"
   fi
+
+  apply_dotfiles "$repo_dir" "$@"
 else
   log "Using remote chezmoi source: $PULL_REPO_URL"
 
   if [ "${DOTFILES_CI:-}" = "true" ]; then
     run chezmoi init "$PULL_REPO_URL" --promptDefaults
-    run chezmoi apply --exclude encrypted "$@"
   else
     run chezmoi init "$PULL_REPO_URL"
-    run chezmoi apply "$@"
   fi
+
+  apply_dotfiles "" "$@"
 fi


### PR DESCRIPTION
## Summary

- continue setup when Homebrew, `age`, `jq`, or `proton-pass-cli` are unavailable
- install optional bootstrap tools through Homebrew when it exists, but do not make them mandatory
- exclude encrypted targets when no usable age identity can be provisioned
- preserve an existing age identity even when validation tooling is unavailable
- skip Proton Pass age and SSH provisioning cleanly when `pass-cli` is missing

## Result

A restricted or unmanaged machine can still receive all usable unencrypted dotfiles and run the package/alias fallbacks using only commands already available on the system. Re-running setup later after installing the missing tools completes encrypted files and Proton Pass provisioning.