### PR TITLE
test: exercise real installs across profiles and package modes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,41 +28,9 @@ jobs:
       - name: Run pre-commit
         run: uv tool run pre-commit run --all-files
 
-  profile-matrix:
-    needs: check
-    name: profiles / ${{ matrix.profiles }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        profiles:
-          - workstation
-          - headless
-          - workstation,development
-          - workstation,laptop
-          - workstation,gaming
-          - headless,server
-          - workstation,owned
-          - workstation,laptop,development,gaming,server,owned
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install chezmoi
-        run: sh -c "$(curl -fsLS https://get.chezmoi.io)" -- -b "$HOME/.local/bin"
-
-      - name: Validate profile set
-        env:
-          DOTFILES_LOCATION: ${{ github.workspace }}
-          DOTFILES_PROFILE_SET: ${{ matrix.profiles }}
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          ./scripts/test-profiles.sh
-
   install-linux:
     needs: check
-    name: install on ubuntu / workstation,development,owned
+    name: sanity / ubuntu / workstation,development,owned / native
     runs-on: ubuntu-latest
 
     container:
@@ -71,26 +39,30 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Run dotfiles install test
+      - name: Run representative install
         env:
           DOTFILES_CI: 'true'
           DOTFILES_LOCATION: ${{ github.workspace }}
           DOTFILES_PROFILES: workstation,development,owned
+          DOTFILES_CI_PACKAGE_MODE: native
+          GITHUB_TOKEN: ${{ github.token }}
         run: ./scripts/ci-install.sh
 
   install-macos:
     needs: check
-    name: install on macos:latest / workstation,laptop,development,owned
+    name: sanity / macos / workstation,laptop,development,owned / brew
     runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Run dotfiles install test
+      - name: Run representative install
         env:
           DOTFILES_CI: 'true'
           DOTFILES_LOCATION: ${{ github.workspace }}
           DOTFILES_PROFILES: workstation,laptop,development,owned
+          DOTFILES_CI_PACKAGE_MODE: brew
+          GITHUB_TOKEN: ${{ github.token }}
         run: ./scripts/ci-install.sh
 
   bootstrap-url-check:
@@ -113,7 +85,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check
-      - profile-matrix
       - install-linux
       - install-macos
       - bootstrap-url-check
@@ -125,19 +96,16 @@ jobs:
           set -eu
 
           check_result='${{ needs.check.result }}'
-          profile_matrix_result='${{ needs.profile-matrix.result }}'
           install_linux_result='${{ needs.install-linux.result }}'
           install_macos_result='${{ needs.install-macos.result }}'
           bootstrap_url_check_result='${{ needs.bootstrap-url-check.result }}'
 
           printf 'check: %s\n' "$check_result"
-          printf 'profile-matrix: %s\n' "$profile_matrix_result"
           printf 'install-linux: %s\n' "$install_linux_result"
           printf 'install-macos: %s\n' "$install_macos_result"
           printf 'bootstrap-url-check: %s\n' "$bootstrap_url_check_result"
 
           test "$check_result" = "success"
-          test "$profile_matrix_result" = "success"
           test "$install_linux_result" = "success"
           test "$install_macos_result" = "success"
           test "$bootstrap_url_check_result" = "success"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,38 @@ jobs:
       - name: Run pre-commit
         run: uv tool run pre-commit run --all-files
 
+  profile-matrix:
+    needs: check
+    name: profiles / ${{ matrix.profiles }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        profiles:
+          - workstation
+          - headless
+          - workstation,development
+          - workstation,laptop
+          - workstation,gaming
+          - headless,server
+          - workstation,owned
+          - workstation,laptop,development,gaming,server,owned
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install chezmoi
+        run: sh -c "$(curl -fsLS https://get.chezmoi.io)" -- -b "$HOME/.local/bin"
+
+      - name: Validate profile set
+        env:
+          DOTFILES_LOCATION: ${{ github.workspace }}
+          DOTFILES_PROFILE_SET: ${{ matrix.profiles }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          ./scripts/test-profiles.sh
+
   install-linux:
     needs: check
     name: install on ubuntu / workstation,development,owned
@@ -81,6 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check
+      - profile-matrix
       - install-linux
       - install-macos
       - bootstrap-url-check
@@ -92,16 +125,19 @@ jobs:
           set -eu
 
           check_result='${{ needs.check.result }}'
+          profile_matrix_result='${{ needs.profile-matrix.result }}'
           install_linux_result='${{ needs.install-linux.result }}'
           install_macos_result='${{ needs.install-macos.result }}'
           bootstrap_url_check_result='${{ needs.bootstrap-url-check.result }}'
 
           printf 'check: %s\n' "$check_result"
+          printf 'profile-matrix: %s\n' "$profile_matrix_result"
           printf 'install-linux: %s\n' "$install_linux_result"
           printf 'install-macos: %s\n' "$install_macos_result"
           printf 'bootstrap-url-check: %s\n' "$bootstrap_url_check_result"
 
           test "$check_result" = "success"
+          test "$profile_matrix_result" = "success"
           test "$install_linux_result" = "success"
           test "$install_macos_result" = "success"
           test "$bootstrap_url_check_result" = "success"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,11 @@ jobs:
 
   install-linux:
     needs: check
-    name: sanity / ubuntu / workstation,development,owned / native
+    name: sanity / fedora / workstation,development,owned / native
     runs-on: ubuntu-latest
 
     container:
-      image: ubuntu:26.04
+      image: fedora:latest
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,24 +25,7 @@ jobs:
           key: pre-commit-5|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
-        id: precommit
-        shell: bash
-        run: |
-          set +e
-          uv tool run pre-commit run --all-files >pre-commit.log 2>&1
-          status=$?
-          git diff >pre-commit.diff
-          cat pre-commit.log
-          exit "$status"
-
-      - name: Upload pre-commit diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pre-commit-diagnostics
-          path: |
-            pre-commit.log
-            pre-commit.diff
+        run: uv tool run pre-commit run --all-files
 
   install-linux:
     needs: check
@@ -76,6 +59,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run full install test
+        shell: bash
         env:
           DOTFILES_CI: 'true'
           DOTFILES_LOCATION: ${{ github.workspace }}
@@ -83,7 +67,16 @@ jobs:
           DOTFILES_CI_PACKAGE_MODE: >-
             ${{ contains(matrix.profiles, 'owned') && 'native' || 'linuxbrew' }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/ci-install.sh
+        run: |
+          set -o pipefail
+          ./scripts/ci-install.sh 2>&1 | tee ci-install.log
+
+      - name: Upload failed install log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-install-${{ strategy.job-index }}
+          path: ci-install.log
 
   install-linux-degraded:
     needs: check
@@ -107,13 +100,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run install without package access or Homebrew
+        shell: bash
         env:
           DOTFILES_CI: 'true'
           DOTFILES_LOCATION: ${{ github.workspace }}
           DOTFILES_PROFILES: workstation
           DOTFILES_CI_PACKAGE_MODE: degraded
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/ci-install.sh
+        run: |
+          set -o pipefail
+          ./scripts/ci-install.sh 2>&1 | tee ci-install.log
+
+      - name: Upload failed degraded-install log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: degraded-install-${{ strategy.job-index }}
+          path: ci-install.log
 
   install-macos:
     needs: check
@@ -135,13 +138,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run full install test
+        shell: bash
         env:
           DOTFILES_CI: 'true'
           DOTFILES_LOCATION: ${{ github.workspace }}
           DOTFILES_PROFILES: ${{ matrix.profiles }}
           DOTFILES_CI_PACKAGE_MODE: brew
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/ci-install.sh
+        run: |
+          set -o pipefail
+          ./scripts/ci-install.sh 2>&1 | tee ci-install.log
+
+      - name: Upload failed macOS-install log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-install-${{ strategy.job-index }}
+          path: ci-install.log
 
   test:
     name: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,38 @@ jobs:
       - name: Run pre-commit
         run: uv tool run pre-commit run --all-files
 
+  profile-matrix:
+    needs: check
+    name: profiles / ${{ matrix.profiles }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        profiles:
+          - workstation
+          - headless
+          - workstation,development
+          - workstation,laptop
+          - workstation,gaming
+          - headless,server
+          - workstation,owned
+          - workstation,laptop,development,gaming,server,owned
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install chezmoi
+        run: sh -c "$(curl -fsLS https://get.chezmoi.io)" -- -b "$HOME/.local/bin"
+
+      - name: Validate profile set
+        env:
+          DOTFILES_LOCATION: ${{ github.workspace }}
+          DOTFILES_PROFILE_SET: ${{ matrix.profiles }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          ./scripts/test-profiles.sh
+
   install-linux:
     needs: check
     name: install on ${{ matrix.image }} / ${{ matrix.profiles }}
@@ -94,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check
+      - profile-matrix
       - install-linux
       - install-macos
     if: always()
@@ -104,13 +137,16 @@ jobs:
           set -eu
 
           check_result='${{ needs.check.result }}'
+          profile_matrix_result='${{ needs.profile-matrix.result }}'
           install_linux_result='${{ needs.install-linux.result }}'
           install_macos_result='${{ needs.install-macos.result }}'
 
           printf 'check: %s\n' "$check_result"
+          printf 'profile-matrix: %s\n' "$profile_matrix_result"
           printf 'install-linux: %s\n' "$install_linux_result"
           printf 'install-macos: %s\n' "$install_macos_result"
 
           test "$check_result" = "success"
+          test "$profile_matrix_result" = "success"
           test "$install_linux_result" = "success"
           test "$install_macos_result" = "success"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,21 @@ jobs:
           key: pre-commit-5|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
-        run: uv tool run pre-commit run --all-files
+        id: precommit
+        shell: bash
+        run: |
+          set +e
+          uv tool run pre-commit run --all-files >pre-commit.log 2>&1
+          status=$?
+          cat pre-commit.log
+          exit "$status"
+
+      - name: Upload pre-commit log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pre-commit-log
+          path: pre-commit.log
 
   install-linux:
     needs: check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,10 +27,81 @@ jobs:
       - name: Run pre-commit
         run: uv tool run pre-commit run --all-files
 
-  profile-matrix:
+  install-linux:
     needs: check
-    name: profiles / ${{ matrix.profiles }}
+    name: >-
+      install / ${{ matrix.image }} / ${{ matrix.profiles }} / ${{ contains(matrix.profiles, 'owned') && 'native-no-brew' || 'linuxbrew-no-root' }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu:26.04
+          - ubuntu:latest
+          - debian:13
+          - debian:sid
+          - fedora:latest
+          - archlinux:latest
+          - cachyos/cachyos:latest
+        profiles:
+          - workstation
+          - headless
+          - workstation,development
+          - workstation,laptop,development,owned
+          - headless,server,owned
+          - workstation,development,gaming,server,owned
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run full install test
+        env:
+          DOTFILES_CI: 'true'
+          DOTFILES_LOCATION: ${{ github.workspace }}
+          DOTFILES_PROFILES: ${{ matrix.profiles }}
+          DOTFILES_CI_PACKAGE_MODE: >-
+            ${{ contains(matrix.profiles, 'owned') && 'native' || 'linuxbrew' }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/ci-install.sh
+
+  install-linux-degraded:
+    needs: check
+    name: degraded / ${{ matrix.image }} / workstation
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu:26.04
+          - debian:13
+          - fedora:latest
+          - archlinux:latest
+          - cachyos/cachyos:latest
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run install without package access or Homebrew
+        env:
+          DOTFILES_CI: 'true'
+          DOTFILES_LOCATION: ${{ github.workspace }}
+          DOTFILES_PROFILES: workstation
+          DOTFILES_CI_PACKAGE_MODE: degraded
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/ci-install.sh
+
+  install-macos:
+    needs: check
+    name: install / macos:latest / ${{ matrix.profiles }} / brew
+    runs-on: macos-latest
 
     strategy:
       fail-fast: false
@@ -39,86 +110,20 @@ jobs:
           - workstation
           - headless
           - workstation,development
-          - workstation,laptop
-          - workstation,gaming
-          - headless,server
-          - workstation,owned
-          - workstation,laptop,development,gaming,server,owned
+          - workstation,laptop,development,owned
+          - headless,server,owned
+          - workstation,development,gaming,server,owned
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install chezmoi
-        run: sh -c "$(curl -fsLS https://get.chezmoi.io)" -- -b "$HOME/.local/bin"
-
-      - name: Validate profile set
-        env:
-          DOTFILES_LOCATION: ${{ github.workspace }}
-          DOTFILES_PROFILE_SET: ${{ matrix.profiles }}
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          ./scripts/test-profiles.sh
-
-  install-linux:
-    needs: check
-    name: install on ${{ matrix.image }} / ${{ matrix.profiles }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Ubuntu/Debian: workstation and headless role coverage.
-          - image: ubuntu:26.04
-            profiles: workstation,development,owned
-          - image: ubuntu:latest
-            profiles: workstation,development,owned
-          - image: debian:13
-            profiles: headless,server,owned
-          - image: debian:sid
-            profiles: headless,development
-
-          # Fedora: owned workstation, headless server, and gaming coverage.
-          - image: fedora:latest
-            profiles: workstation,development,owned
-          - image: fedora:latest
-            profiles: headless,server,owned
-          - image: fedora:latest
-            profiles: workstation,development,gaming,server,owned
-
-          # Arch/CachyOS: rolling workstation/development coverage.
-          - image: archlinux:latest
-            profiles: workstation,development,owned
-          - image: cachyos/cachyos:latest
-            profiles: workstation,development,owned
-
-    container:
-      image: ${{ matrix.image }}
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Run dotfiles install test
+      - name: Run full install test
         env:
           DOTFILES_CI: 'true'
           DOTFILES_LOCATION: ${{ github.workspace }}
           DOTFILES_PROFILES: ${{ matrix.profiles }}
+          DOTFILES_CI_PACKAGE_MODE: brew
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/ci-install.sh
-
-  install-macos:
-    needs: check
-    name: install on macos:latest / workstation,laptop,development,owned
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Run dotfiles install test
-        env:
-          DOTFILES_CI: 'true'
-          DOTFILES_LOCATION: ${{ github.workspace }}
-          DOTFILES_PROFILES: workstation,laptop,development,owned
         run: ./scripts/ci-install.sh
 
   test:
@@ -126,8 +131,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check
-      - profile-matrix
       - install-linux
+      - install-linux-degraded
       - install-macos
     if: always()
 
@@ -137,16 +142,16 @@ jobs:
           set -eu
 
           check_result='${{ needs.check.result }}'
-          profile_matrix_result='${{ needs.profile-matrix.result }}'
           install_linux_result='${{ needs.install-linux.result }}'
+          degraded_result='${{ needs.install-linux-degraded.result }}'
           install_macos_result='${{ needs.install-macos.result }}'
 
           printf 'check: %s\n' "$check_result"
-          printf 'profile-matrix: %s\n' "$profile_matrix_result"
           printf 'install-linux: %s\n' "$install_linux_result"
+          printf 'install-linux-degraded: %s\n' "$degraded_result"
           printf 'install-macos: %s\n' "$install_macos_result"
 
           test "$check_result" = "success"
-          test "$profile_matrix_result" = "success"
           test "$install_linux_result" = "success"
+          test "$degraded_result" = "success"
           test "$install_macos_result" = "success"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,15 +31,18 @@ jobs:
           set +e
           uv tool run pre-commit run --all-files >pre-commit.log 2>&1
           status=$?
+          git diff >pre-commit.diff
           cat pre-commit.log
           exit "$status"
 
-      - name: Upload pre-commit log
+      - name: Upload pre-commit diagnostics
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: pre-commit-log
-          path: pre-commit.log
+          name: pre-commit-diagnostics
+          path: |
+            pre-commit.log
+            pre-commit.diff
 
   install-linux:
     needs: check

--- a/home/.chezmoiscripts/run_onchange_after_05-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_05-packages.sh.tmpl
@@ -44,7 +44,7 @@ set -eu
 {{- end -}}
 {{- end }}
 
-{{ define "caskLines" }}
+{{- define "caskLines" -}}
 {{- $profiles := index . 0 -}}
 {{- $casks := index . 1 | default (list) -}}
 {{- range $cask := $casks -}}
@@ -55,13 +55,13 @@ set -eu
 {{- $enabledGroup := or (eq $group "core") (has $group $profiles) -}}
 {{- if and $name $enabledGroup -}}
 {{- if $tap -}}
-{{- printf "%s/%s\n" $tap $caskName -}}
+{{ printf "%s/%s\n" $tap $caskName }}
 {{- else -}}
-{{- printf "%s\n" $caskName -}}
+{{ printf "%s\n" $caskName }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{ end }}
+{{- end }}
 
 PROFILE_OWNED="{{ if has "owned" $profiles }}true{{ else }}false{{ end }}"
 
@@ -129,7 +129,7 @@ run_as_root() {
     run sudo "$@"
   else
     printf 'Need root or sudo to install packages\n' >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -181,43 +181,13 @@ install_root_packages() {
   run_as_root "$@" $packages
 }
 
-install_brew_casks() {
-  casks="$(normalize_packages "$BREW_CASKS")"
-
-  if [ -z "$casks" ]; then
-    printf 'No Homebrew casks selected\n'
-    return 0
-  fi
-
-  print_packages "Homebrew cask" "$casks"
-
-  # shellcheck disable=SC2086
-  run brew install --quiet --cask $casks
-}
-
-prepare_brew_ci() {
-  if [ "${DOTFILES_CI:-}" != "true" ]; then
-    return 0
-  fi
-
-  if brew tap | grep -Fxq 'aws/tap'; then
-    run brew untap aws/tap
-  fi
-}
-
-install_brew() {
-  if ! command -v brew >/dev/null 2>&1; then
-    printf 'Homebrew is not installed; skipping packages\n' >&2
-    exit 0
-  fi
-
-  prepare_brew_ci
-
-  install_user_packages Homebrew "$BREW_PACKAGES" brew install --quiet
-  install_brew_casks
+homebrew_enabled() {
+  [ "${DOTFILES_DISABLE_HOMEBREW:-}" != "1" ]
 }
 
 find_brew() {
+  homebrew_enabled || return 1
+
   if command -v brew >/dev/null 2>&1; then
     command -v brew
     return 0
@@ -238,12 +208,41 @@ find_brew() {
   return 1
 }
 
+install_brew_casks() {
+  casks="$(normalize_packages "$BREW_CASKS")"
+
+  if [ -z "$casks" ]; then
+    printf 'No Homebrew casks selected\n'
+    return 0
+  fi
+
+  print_packages "Homebrew cask" "$casks"
+
+  # shellcheck disable=SC2086
+  run brew install --quiet --cask $casks
+}
+
+install_brew() {
+  if ! homebrew_enabled; then
+    printf 'Homebrew is disabled; skipping packages\n'
+    return 0
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    printf 'Homebrew is not installed; skipping packages\n' >&2
+    return 0
+  fi
+
+  install_user_packages Homebrew "$BREW_PACKAGES" brew install --quiet
+  install_brew_casks
+}
+
 install_linuxbrew() {
   package_block="$LINUXBREW_PACKAGES"
 
-  # Owned Linux machines use the native package manager for normal packages.
-  # Only explicitly Linuxbrew-selected supplemental tools are installed there.
-  if [ "$PROFILE_OWNED" = "true" ] || [ "${DOTFILES_CI:-}" = "true" ]; then
+  # Owned Linux machines use the native package manager for the normal catalog
+  # and Linuxbrew only for packages explicitly selected for Linuxbrew.
+  if [ "$PROFILE_OWNED" = "true" ]; then
     package_block="$LINUXBREW_SUPPLEMENTAL_PACKAGES"
   fi
 
@@ -256,12 +255,11 @@ install_linuxbrew() {
   brew_command="$(find_brew || true)"
 
   if [ -z "$brew_command" ]; then
-    printf '%s\n' \
-      'Homebrew was not found; skipping Linuxbrew packages.' >&2
+    printf '%s\n' 'Homebrew was not found; skipping Linuxbrew packages.' >&2
     return 0
   fi
 
-  print_packages "Linuxbrew" "$packages"
+  print_packages Linuxbrew "$packages"
 
   printf '%s\n' "$packages" |
     while IFS= read -r package; do
@@ -286,8 +284,6 @@ install_apt_ppas() {
   # shellcheck disable=SC1091
   . /etc/os-release
 
-  # Launchpad PPAs are Ubuntu-specific. Do not attempt to add them on Debian
-  # or another distribution that happens to use apt.
   if [ "${ID:-}" != "ubuntu" ]; then
     printf 'Skipping Ubuntu PPAs on distribution: %s\n' "${ID:-unknown}"
     return 0
@@ -307,29 +303,24 @@ install_apt_ppas() {
 $ppas
 EOF
 
-  # Refresh metadata after adding the repositories.
   run_as_root apt-get update
 }
 
 install_apt() {
-  if [ "$PROFILE_OWNED" != "true" ] && [ "${DOTFILES_CI:-}" != "true" ]; then
+  if [ "$PROFILE_OWNED" != "true" ]; then
     printf 'Skipping apt packages because owned profile is not enabled\n'
     return 0
   fi
 
-  # Initial metadata is needed to install software-properties-common.
   run_as_root apt-get update
-
-  # On Ubuntu, add configured PPAs before installing the package catalog.
   install_apt_ppas
-
   install_root_packages apt "$APT_PACKAGES" \
     env DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends
 }
 
 install_dnf() {
-  if [ "$PROFILE_OWNED" != "true" ] && [ "${DOTFILES_CI:-}" != "true" ]; then
+  if [ "$PROFILE_OWNED" != "true" ]; then
     printf 'Skipping dnf packages because owned profile is not enabled\n'
     return 0
   fi
@@ -338,7 +329,7 @@ install_dnf() {
 }
 
 install_pacman() {
-  if [ "$PROFILE_OWNED" != "true" ] && [ "${DOTFILES_CI:-}" != "true" ]; then
+  if [ "$PROFILE_OWNED" != "true" ]; then
     printf 'Skipping pacman packages because owned profile is not enabled\n'
     return 0
   fi
@@ -359,7 +350,7 @@ linux)
   elif command -v pacman >/dev/null 2>&1; then
     install_pacman
   else
-    printf 'No supported package manager found; skipping packages\n' >&2
+    printf 'No supported package manager found; skipping native packages\n' >&2
   fi
 
   install_linuxbrew

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -5,13 +5,13 @@ if [ "${DOTFILES_DEBUG:-}" = "1" ]; then
   set -x
 fi
 
-ci_pkgs="${DOTFILES_CI_PKGS:-git curl jq}"
-
-set -f
-# DOTFILES_CI_PKGS is a space-separated package list.
-# shellcheck disable=SC2086
-set -- $ci_pkgs
-set +f
+repo_root="${DOTFILES_LOCATION:-${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}}"
+profiles="${DOTFILES_PROFILES:-workstation,development,owned}"
+package_mode="${DOTFILES_CI_PACKAGE_MODE:-native}"
+ci_user="dotfiles"
+ci_home="/home/$ci_user"
+brew_prefix="/home/linuxbrew/.linuxbrew"
+base_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 log() {
   printf '%s\n' "$*"
@@ -26,11 +26,222 @@ section() {
   printf '\n==> %s\n' "$*"
 }
 
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+install_linux_harness() {
+  section "Installing CI harness dependencies"
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run apt-get update
+    run env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      bash build-essential ca-certificates curl file git passwd procps sudo util-linux
+  elif command -v dnf >/dev/null 2>&1; then
+    run dnf install -y \
+      bash ca-certificates curl file findutils gcc gcc-c++ git make procps-ng \
+      shadow-utils sudo util-linux
+  elif command -v pacman >/dev/null 2>&1; then
+    run pacman -Sy --noconfirm --needed \
+      base-devel bash ca-certificates curl file git procps-ng shadow sudo util-linux
+  else
+    fail "unsupported Linux package manager"
+  fi
+}
+
+create_ci_user() {
+  section "Creating unprivileged install user"
+
+  if ! id "$ci_user" >/dev/null 2>&1; then
+    run useradd --create-home --shell /bin/bash "$ci_user"
+  fi
+
+  run mkdir -p "$ci_home"
+  run chown -R "$ci_user:$ci_user" "$ci_home"
+
+  # GitHub mounts the checkout outside the test user's home. The source only
+  # needs to be readable; all generated state is written below ci_home.
+  run chmod -R a+rX "$repo_root"
+}
+
+configure_native_access() {
+  section "Allowing native package installation"
+
+  printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$ci_user" \
+    >"/etc/sudoers.d/$ci_user"
+  chmod 0440 "/etc/sudoers.d/$ci_user"
+}
+
+install_linuxbrew() {
+  section "Installing Linuxbrew for the unowned-machine path"
+
+  run mkdir -p "$brew_prefix"
+  run chown -R "$ci_user:$ci_user" /home/linuxbrew
+  run curl -fsSL \
+    https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh \
+    -o /tmp/install-homebrew.sh
+  run chmod 0755 /tmp/install-homebrew.sh
+
+  run_as_ci_user env \
+    NONINTERACTIVE=1 \
+    CI=1 \
+    HOMEBREW_NO_ANALYTICS=1 \
+    /bin/bash /tmp/install-homebrew.sh
+
+  ci_path="$brew_prefix/bin:$brew_prefix/sbin:$ci_path"
+  run_as_ci_user brew --version
+}
+
+run_as_ci_user() {
+  run runuser -u "$ci_user" -- env \
+    HOME="$ci_home" \
+    USER="$ci_user" \
+    LOGNAME="$ci_user" \
+    SHELL=/bin/bash \
+    PATH="$ci_path" \
+    "$@"
+}
+
+ci_user_has() {
+  runuser -u "$ci_user" -- env \
+    HOME="$ci_home" \
+    USER="$ci_user" \
+    LOGNAME="$ci_user" \
+    SHELL=/bin/bash \
+    PATH="$ci_path" \
+    sh -c "command -v \"$1\" >/dev/null 2>&1"
+}
+
+run_linux_install() {
+  install_linux_harness
+  create_ci_user
+
+  ci_path="$ci_home/.local/bin:$base_path"
+  disable_homebrew=0
+  expect_packages=true
+
+  case "$package_mode" in
+    native)
+      case ",$profiles," in
+        *,owned,*) ;;
+        *) fail "native package mode requires the owned profile" ;;
+      esac
+
+      configure_native_access
+      disable_homebrew=1
+      ;;
+    linuxbrew)
+      case ",$profiles," in
+        *,owned,*) fail "linuxbrew package mode must not use the owned profile" ;;
+        *) ;;
+      esac
+
+      install_linuxbrew
+      ;;
+    degraded)
+      case ",$profiles," in
+        *,owned,*) fail "degraded package mode must not use the owned profile" ;;
+        *) ;;
+      esac
+
+      disable_homebrew=1
+      expect_packages=false
+      ;;
+    *)
+      fail "unknown DOTFILES_CI_PACKAGE_MODE: $package_mode"
+      ;;
+  esac
+
+  section "Running actual dotfiles install"
+  run_as_ci_user env \
+    DOTFILES_CI=true \
+    DOTFILES_LOCATION="$repo_root" \
+    DOTFILES_PROFILES="$profiles" \
+    DOTFILES_CI_PACKAGE_MODE="$package_mode" \
+    DOTFILES_DISABLE_HOMEBREW="$disable_homebrew" \
+    DOTFILES_CI_EXPECT_PACKAGES="$expect_packages" \
+    GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
+    sh "$repo_root/setup.sh"
+
+  section "Checking package path"
+  case "$package_mode" in
+    native)
+      if ci_user_has brew; then
+        fail "native package test unexpectedly exposed Homebrew"
+      fi
+      ci_user_has jq || fail "native package install did not provide jq"
+      ci_user_has nvim || fail "native package install did not provide nvim"
+      ;;
+    linuxbrew)
+      ci_user_has brew || fail "Linuxbrew package test cannot find brew"
+      ci_user_has jq || fail "Linuxbrew package install did not provide jq"
+      ci_user_has lsd || fail "Linuxbrew package install did not provide lsd"
+      ci_user_has nvim || fail "Linuxbrew package install did not provide nvim"
+      ;;
+    degraded)
+      if ci_user_has brew; then
+        fail "degraded package test unexpectedly exposed Homebrew"
+      fi
+      ;;
+  esac
+
+  section "Running install validation"
+  run_as_ci_user env \
+    DOTFILES_CI=true \
+    DOTFILES_LOCATION="$repo_root" \
+    DOTFILES_PROFILES="$profiles" \
+    DOTFILES_CI_PACKAGE_MODE="$package_mode" \
+    DOTFILES_CI_EXPECT_PACKAGES="$expect_packages" \
+    sh "$repo_root/scripts/test-install.sh"
+
+  if ci_user_has jq; then
+    section "Validating the installed profile"
+    run_as_ci_user env \
+      DOTFILES_CI=true \
+      DOTFILES_LOCATION="$repo_root" \
+      DOTFILES_PROFILE_SET="$profiles" \
+      sh "$repo_root/scripts/test-profiles.sh"
+  else
+    log "Skipping profile renderer validation because jq is unavailable"
+  fi
+}
+
+run_macos_install() {
+  [ "$package_mode" = "brew" ] \
+    || fail "macOS CI requires DOTFILES_CI_PACKAGE_MODE=brew"
+
+  export DOTFILES_CI=true
+  export DOTFILES_LOCATION="$repo_root"
+  export DOTFILES_PROFILES="$profiles"
+  export DOTFILES_CI_PACKAGE_MODE="$package_mode"
+  export DOTFILES_CI_EXPECT_PACKAGES=true
+  export HOMEBREW_NO_ANALYTICS=1
+  export HOMEBREW_NO_AUTO_UPDATE=1
+  export PATH="$HOME/.local/bin:$PATH"
+
+  section "Running actual dotfiles install"
+  run sh "$repo_root/setup.sh"
+
+  section "Checking Homebrew package path"
+  command -v brew >/dev/null 2>&1 || fail "Homebrew is unavailable"
+  command -v jq >/dev/null 2>&1 || fail "Homebrew package install did not provide jq"
+  command -v lsd >/dev/null 2>&1 || fail "Homebrew package install did not provide lsd"
+  command -v nvim >/dev/null 2>&1 || fail "Homebrew package install did not provide nvim"
+
+  section "Running install validation"
+  run sh "$repo_root/scripts/test-install.sh"
+
+  section "Validating the installed profile"
+  DOTFILES_PROFILE_SET="$profiles" run sh "$repo_root/scripts/test-profiles.sh"
+}
+
 log "Starting CI dotfiles install"
 log "HOME=$HOME"
 log "PWD=$PWD"
-log "DOTFILES_LOCATION=${DOTFILES_LOCATION:-}"
-log "DOTFILES_CI=${DOTFILES_CI:-}"
+log "DOTFILES_LOCATION=$repo_root"
+log "DOTFILES_PROFILES=$profiles"
+log "DOTFILES_CI_PACKAGE_MODE=$package_mode"
 log "PATH=$PATH"
 
 if [ -f /etc/os-release ]; then
@@ -39,51 +250,14 @@ if [ -f /etc/os-release ]; then
   cat /etc/os-release
 fi
 
-if [ "${DOTFILES_CI_SKIP_PACKAGE_SETUP:-}" = "1" ]; then
-  log "Skipping CI package setup because DOTFILES_CI_SKIP_PACKAGE_SETUP=1"
-else
-  section "Installing CI dependencies"
-
-  if command -v brew >/dev/null 2>&1; then
-    log "macOS CI packages: $*"
-    run brew install "$@" || true
-  else
-    set -- "$@" ca-certificates
-    log "Linux CI packages: $*"
-
-    if command -v apt-get >/dev/null 2>&1; then
-      run apt-get update
-      run env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@"
-    elif command -v dnf >/dev/null 2>&1; then
-      run dnf install -y "$@"
-    elif command -v apk >/dev/null 2>&1; then
-      run apk add --no-cache "$@"
-    elif command -v pacman >/dev/null 2>&1; then
-      run pacman -Sy --noconfirm --needed "$@"
-    else
-      printf 'Unsupported package manager\n' >&2
-      exit 1
-    fi
-  fi
-fi
-
-export DOTFILES_CI=true
-export DOTFILES_LOCATION="${DOTFILES_LOCATION:-${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}}"
-export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
-
-if command -v apt-get >/dev/null 2>&1; then
-  section "Installing tree-sitter CLI"
-  run "$DOTFILES_LOCATION/scripts/install-tree-sitter-cli.sh"
-
-  section "Ensuring a supported Neovim version"
-  run "$DOTFILES_LOCATION/scripts/install-neovim.sh"
-fi
-
-section "Running setup.sh"
-run sh "$DOTFILES_LOCATION/setup.sh"
-
-section "Running install validation"
-run "$DOTFILES_LOCATION/scripts/test-install.sh"
-
-section "Running profile validation"
-run "$DOTFILES_LOCATION/scripts/test-profiles.sh"
+case "$(uname -s)" in
+  Darwin)
+    run_macos_install
+    ;;
+  Linux)
+    run_linux_install
+    ;;
+  *)
+    fail "unsupported operating system: $(uname -s)"
+    ;;
+esac

--- a/scripts/test-profiles.sh
+++ b/scripts/test-profiles.sh
@@ -3,11 +3,13 @@ set -eu
 
 VALID_PROFILE_SETS="
 workstation
-workstation,development
-workstation,laptop,development,owned
 headless
-headless,server,owned
-workstation,development,gaming,server,owned
+workstation,development
+workstation,laptop
+workstation,gaming
+headless,server
+workstation,owned
+workstation,laptop,development,gaming,server,owned
 "
 
 INVALID_PROFILE_SETS="
@@ -132,6 +134,11 @@ test_invalid_profile_set() {
 
 command -v chezmoi >/dev/null 2>&1 || fail "missing command: chezmoi"
 command -v jq >/dev/null 2>&1 || fail "missing command: jq"
+
+if [ -n "${DOTFILES_PROFILE_SET:-}" ]; then
+  test_profile_set "$DOTFILES_PROFILE_SET"
+  exit 0
+fi
 
 printf '%s\n' "$VALID_PROFILE_SETS" | awk 'NF' | while IFS= read -r profiles; do
   test_profile_set "$profiles"


### PR DESCRIPTION
## Summary

- replace render-only profile matrix coverage with real `setup.sh` installs
- run every valid profile set on every supported Linux container and on macOS
- test owned Linux profiles with native package managers while keeping Homebrew unavailable
- test non-owned Linux profiles as an unprivileged user with Linuxbrew and no sudo access
- add degraded Linux jobs with neither package privileges nor Homebrew
- validate the installed files and expected package path after each setup
- reduce `main.yml` to representative Fedora/macOS sanity installs for merge-queue output

## Dependency

This PR is stacked on #276 so the degraded matrix tests the graceful-install behavior introduced there. Merge #276 first, then retarget this PR to `main`.

## PR coverage

Each platform runs these complete profile sets:

- `workstation`
- `headless`
- `workstation,development`
- `workstation,laptop,development,owned`
- `headless,server,owned`
- `workstation,development,gaming,server,owned`

Linux platforms:

- Ubuntu 26.04
- current Ubuntu
- Debian 13
- Debian sid
- Fedora
- Arch Linux
- CachyOS

Package-path assertions ensure the jobs are not accidentally passing through the wrong installer. Native jobs reject an exposed `brew`; Linuxbrew jobs require `brew`, `jq`, `lsd`, and `nvim`; degraded jobs run without either package path.