### PR TITLE
fix: persist TMPDIR fallback for noexec /tmp

### DIFF
--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -7,6 +7,23 @@ export XDG_CONFIG_HOME="$HOME/.config"
 export XDG_DATA_HOME="$HOME/.local/share"
 export XDG_STATE_HOME="$HOME/.local/state"
 
+# Chezmoi executes rendered scripts from TMPDIR. Some managed systems mount
+# /tmp with noexec, so move temporary files onto the executable home dataset.
+if [ -z "${TMPDIR:-}" ] && command -v findmnt >/dev/null 2>&1; then
+  _dotfiles_tmp_options="$(findmnt -no OPTIONS -T /tmp 2>/dev/null || :)"
+
+  case ",$_dotfiles_tmp_options," in
+    *,noexec,*)
+      TMPDIR="$XDG_CACHE_HOME/tmp"
+      mkdir -p "$TMPDIR"
+      chmod 700 "$TMPDIR"
+      export TMPDIR
+      ;;
+  esac
+
+  unset _dotfiles_tmp_options
+fi
+
 export HOMEBREW_NO_ANALYTICS=1
 
 for dir in "$HOME/.local/bin" "$HOME/bin"; do


### PR DESCRIPTION
## Summary

- detect `noexec` on `/tmp` from `.zshenv`
- set `TMPDIR` to `$XDG_CACHE_HOME/tmp` only when needed
- create the fallback directory with mode `0700`
- keep ordinary systems using their existing temporary directory

This makes subsequent interactive `chezmoi` commands such as `cz apply` work after the initial bootstrap on systems like TrueNAS.